### PR TITLE
Remove controller and node startup flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ Kubernetes Release | DigitalOcean CSI Driver Version
 The [DigitalOcean Kubernetes](https://www.digitalocean.com/products/kubernetes/) product comes with the CSI driver pre-installed and no further steps are required.
 
 ---
+**Driver modes:**
+
+By default, driver runs in both controller and node mode. It would create disk Volumes on DigitalOcean infrastructure and mount them on the required node.
+
+Driver can be run in **controller only mode** outside DigitalOcean droplets.
+To use this mode `--region` flag (valid DigitalOcean region slug) must be provided together with `--token` flag (DigitalOcean API token).
+
+Alternatively driver can be run in **node only mode** on DigitalOcean droplets. Driver would only handle node related requests like mount volume.
+To us this mode `--region` and `--token` flags must not be provided.
+
+Skip secret creation (section 1. in following deployment instructions) when using **node only mode** as API token is not required.
+
+---
 
 **Requirements:**
 

--- a/cmd/do-csi-plugin/main.go
+++ b/cmd/do-csi-plugin/main.go
@@ -30,16 +30,14 @@ import (
 
 func main() {
 	var (
-		endpoint     = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint.")
-		token        = flag.String("token", "", "DigitalOcean access token.")
-		url          = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL.")
-		isController = flag.Bool("controller-mode", true, "Run driver with controller mode.")
-		isNode       = flag.Bool("node-mode", true, "Run driver with node mode.")
-		region       = flag.String("region", "", "DO region slug. Required when running in controller only mode. Don't use if running in Node Mode.")
-		doTag        = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach.")
-		driverName   = flag.String("driver-name", driver.DefaultDriverName, "Name for the driver.")
-		debugAddr    = flag.String("debug-addr", "", "Address to serve the HTTP debug server on.")
-		version      = flag.Bool("version", false, "Print the version and exit.")
+		endpoint   = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint.")
+		token      = flag.String("token", "", "DigitalOcean access token.")
+		url        = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL.")
+		region     = flag.String("region", "", "DigitalOcean region slug. Required when running not on DigitalOcean droplet.")
+		doTag      = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach.")
+		driverName = flag.String("driver-name", driver.DefaultDriverName, "Name for the driver.")
+		debugAddr  = flag.String("debug-addr", "", "Address to serve the HTTP debug server on.")
+		version    = flag.Bool("version", false, "Print the version and exit.")
 	)
 	flag.Parse()
 
@@ -48,11 +46,11 @@ func main() {
 		os.Exit(0)
 	}
 
-	if *isController && *token == "" {
-		log.Fatalln("token required when running with controller-mode")
+	if *token == "" && *region != "" {
+		log.Fatalln("region flag must not be set when driver is running in node mode (with unset token flag)")
 	}
 
-	drv, err := driver.NewDriver(*endpoint, *token, *url, *isController, *isNode, *region, *doTag, *driverName, *debugAddr)
+	drv, err := driver.NewDriver(*endpoint, *token, *url, *region, *doTag, *driverName, *debugAddr)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
- Remove isController and isNode flags.
- Error if token flag is not provided, but region flag is provided. Region flag is not required as driver is running in node mode on DigitalOcean droplet.
- Add documentation about available driver modes.